### PR TITLE
Adaptations to be able to use multiple files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ i18ncsv2json
 
 i18n csv file to json convetor.
 
-Expect one csv file `tools.csv`, with following structure:
+Expect one or more csv file with following structure:
 
 key   | en         | de 
 ------|------------|------------
@@ -28,6 +28,34 @@ And one is `tools.de.json`:
       "home": "Startseite"
     }
 
+### Working with multiple files
+
+Multiple files can be provided as arguments.
+
+Execute following command:
+ 
+    i18ncsv2json tools.csv file.csv
+ 
+Will generate 4 files:
+- `tools.en.json`
+- `tools.de.json`
+- `file.en.json`
+- `file.de.json`
+
+Wildcard can also be used in path
+
+    i18ncsv2json *.csv
+
+Output for the same language can be merge together into a single file with the `merge` option.
+ 
+Execute following command:
+ 
+    i18ncsv2json tools.csv file.csv --merge
+ 
+Will generate 2 files:
+- `en.json`
+- `de.json`
+
 ### Field delimiter
  
  If you are working with English locale, the field delimiter in csv files is the `,` character. But for other locales (e.g. french) the `;` character is used. You can adapt the csv field delimiter with the `fieldDelimiter` option.
@@ -47,15 +75,17 @@ And one is `tools.de.json`:
 Usage
 -----
 
-    Usage: i18ncsv2json [options] <file ...>
+    i18ncsv2json [options] <files  ...>
 
-    Options:
-
-      -h, --help               output usage information
-      -V, --version            output the version number
-      -p, --path [value]       output path
-      -d, --delimeter [value]  delimeter between filename and lang
-      -t, --transpose          transpose input csv file
-      -f, --fieldDelimiter [value]  delimiter between fields
-      -r, --readEncoding [value]    encoding to use to read files
-      -w, --writeEncoding [value]   encoding to use to write files
+Options:  
+|Short flag|Flag                      |Description                                                             |
+|----------|--------------------------|------------------------------------------------------------------------|
+|-h        |--help                    |output usage information                                                |
+|-V        |--version                 |output the version number                                               |
+|-p        |--path [value]            |output path                                                             |
+|-d        |--delimeter [value]       |delimeter between filename and lang                                     |
+|-t        |--transpose               |transpose input csv file                                                |
+|-f        |--fieldDelimiter [value]  |delimiter between fields                                                |
+|-r        |--readEncoding [value]    |encoding to use to read files                                           |
+|-w        |--writeEncoding [value]   |encoding to use to write files                                          |
+|-m        |--merge                   |merge all csv files into a single json file                             |

--- a/index.js
+++ b/index.js
@@ -12,30 +12,37 @@ program
   .option('-f, --fieldDelimiter [value]', 'delimiter between fields', ',')
   .option('-r, --readEncoding [value]', 'encoding to use to read files')
   .option('-w, --writeEncoding [value]', 'encoding to use to write files')
+  .option('-m, --merge ', 'merge all csv files into a single json file')
   .parse(process.argv);
 
-var file = program.args[0];
-
-if (!file) {
-   console.error('no csv file is given!');
+if (program.args.length === 0) {
+   console.error('No files provided as argument!');
    process.exit(1);
 }
 
-var title = file.split('.').slice(0, -1).join('.');
-
 var fs = require('fs');
 var parse = require('csv-parse');
+var path = require('path')
+var merge = require('lodash.merge');
+var objectPath = require('object-path');
 
 const readOptions = (program.readEncoding ? { 'encoding': program.readEncoding } : null);
 const writeOptions = (program.writeEncoding ? { 'encoding': program.writeEncoding } : null);
+const parseOptions = { 'delimiter': program.fieldDelimiter || ',' };
 
-fs.readFile(file, readOptions, function (err, content) {
-  if (err) {
-     console.error('file is not readable!');
-     process.exit(1);
+let previousLangData = {};
+
+const p = path.join(program.path);
+require('mkdirp')(p);
+
+program.args.forEach((file) => {
+  let content;
+  try {
+    content = fs.readFileSync(file, readOptions);
+  } catch (err) {
+    console.error('File ' + file + ' is not readable!', err);
+    process.exit(1);
   }
-
-  const parseOptions = { 'delimiter': program.fieldDelimiter || ',' };
 
   parse(content, parseOptions, function (err, trans) {
     if (program.transpose) {
@@ -58,8 +65,6 @@ fs.readFile(file, readOptions, function (err, content) {
     var entry = [];
     var key = '';
 
-    var objectPath = require('object-path');
-
     while (entry = trans.shift()) {
       key = entry.shift();
 
@@ -70,10 +75,6 @@ fs.readFile(file, readOptions, function (err, content) {
       }
     }
 
-    var path = require('path')
-    var p = path.join(program.path);
-
-    require('mkdirp')(p);
 
     var target_file = '';
     var target = '';
@@ -81,14 +82,31 @@ fs.readFile(file, readOptions, function (err, content) {
     langs = o_langs.slice();
     while (lang = langs.shift()) {
       lang = lang.toLowerCase();
-      target = [title, lang].join(program.delimeter);
+      if (program.merge) {
+        target = lang;
+      } else {
+        var title = file.split('.').slice(0, -1).join('.');
+        target = [title, lang].join(program.delimeter);
+      }
       target = [target, 'json'].join('.');
 
-      target_file = path.join(p, target);
+      target_file = path.join(p, path.basename(target));
 
-      console.log(target_file)
-      fs.writeFile(target_file, JSON.stringify(buffer[lang], null, 2), writeOptions);
+      let currentFileLang = buffer[lang];
+      if (program.merge) {
+        try {
+          if (!previousLangData[lang]) {
+            console.log(target_file);
+            previousLangData[lang] = {};
+          }
+          currentFileLang = merge(currentFileLang, previousLangData[lang]);
+          previousLangData[lang] = currentFileLang; 
+        } catch (err) { /* Do nothing  */ }
+      } else {
+        console.log(target_file)
+      }
+      fs.writeFileSync(target_file, JSON.stringify(buffer[lang], null, 2), writeOptions);
     }
-
+    
   });
 });

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "commander": "^2.9.0",
     "csv-parse": "^1.0.1",
     "lodash-transpose": "^0.1.1",
+    "lodash.merge": "^4.6.0",
     "mkdirp": "^0.5.1",
     "object-path": "^0.9.2"
   },


### PR DESCRIPTION
Adaptations to be able to use multiple files and merge output into a single file by language

Simplified the version compare to my first pull request. Directories cannot be used anymore but wildcards should be used to specify multiple files. This removed the need for the additional extension option that I had first added.